### PR TITLE
Adding example for TLSMAN module

### DIFF
--- a/apps/tlsman/Makefile
+++ b/apps/tlsman/Makefile
@@ -1,0 +1,65 @@
+APPLICATION = tlsman_simple
+
+BOARD ?= native
+
+# NOTE: This test uses an experimental branch.
+# NOTE: ../install.sh must be called at least one time.
+RIOTBASE ?= $(CURDIR)/../../betas/tlsman
+
+# Minimun Network setting
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6_default
+
+# Minimun Shell commands settings
+USEMODULE += shell
+
+# Optional modules
+USEMODULE += gnrc_icmpv6_echo
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# Relevant modules for TLSMAN
+USEMODULE += tlsman
+USEMODULE += gnrc_sock_udp
+
+# Special include directory with the (D)TLS keys required for the test
+INCLUDES += -I$(APPDIR)/keys
+
+# This is intented to be handled by sock_secure for normal applications
+# NOTE (TODO): Should be equivalent to use `USEMODULE += tlsman_tinydtls`
+USEPKG += tinydtls
+ifneq (,$(filter tinydtls,$(USEPKG)))
+	USEMODULE += tlsman_tinydtls
+
+	CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
+	# NOTE: For "rehandhsake", tinydtls requires at least two peers.
+	# With the default values, the boards will not crash but tinydtls will
+	# be unable to generate the context.
+	CFLAGS += -DDTLS_CONTEXT_MAX=2
+	CFLAGS += -DDTLS_PEER_MAX=2
+	CFLAGS += -DDTLS_HANDSHAKE_MAX=2
+
+	ifneq (,$(filter gnrc_sock_async,$(USEMODULE)))
+		# NOTE: Temporary while sock_asyn is in beta (this called by gnrc_sock_async)
+		USEMODULE += core_thread_flags
+
+		# NOTE: At least for tinyDTLS, we are making use of event timeout
+		USEMODULE += event_timeout
+	endif
+endif
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# NOTE: ifneq is unique to this repository
+ifneq (,$(wildcard $(RIOTBASE)/Makefile.include))
+include $(RIOTBASE)/Makefile.include
+else
+$(error This requires a beta branch. Plase, run: "install.sh from the top")
+endif

--- a/apps/tlsman/README.md
+++ b/apps/tlsman/README.md
@@ -1,0 +1,3 @@
+This is a test application for the TLSMAN Module [Currently PR #9066](https://github.com/RIOT-OS/RIOT/pull/9066)
+
+Please, reminds that this module is not intended to be used directly by the user, but by means of another module. These examples are just to show the simplicity in relation to the client/server sides on the dtls-echo example.

--- a/apps/tlsman/client.c
+++ b/apps/tlsman/client.c
@@ -1,0 +1,84 @@
+
+ #include <stdio.h>
+
+#include "net/sock/udp.h"
+#include "net/tlsman.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+/* Our custom response handler (optional) */
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
+{
+
+    (void) sock;
+    printf("Answer (%i bytes): \t--%s--\n", data_size, data);
+}
+
+int _client_side(char *addr_str,  uint16_t  port)
+{
+    sock_udp_t udp_sock;
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+    uint8_t tlsman_flags =  TLSMAN_FLAG_STACK_UNIVERSAL |
+                            TLSMAN_FLAG_SIDE_CLIENT;
+
+    tlsman_session_t dtls_session;
+    uint8_t packet_rcvd[DTLS_MAX_BUF];
+
+    DEBUG("Remote server: [%s]:%u\n", addr_str, port);
+
+    local.port = (unsigned short) port + 10;
+    remote.port = (unsigned short) port;
+    ipv6_addr_from_str((ipv6_addr_t *)&remote.addr.ipv6, addr_str);
+    sock_udp_create(&udp_sock, &local, &remote, 0);
+
+    ssize_t res = tlsman_init_context((tlsman_ep_t *) &local,
+                                     (tlsman_ep_t *) &remote,
+                                    &dtls_session, &udp_sock,
+                                    _resp_handler, tlsman_flags);
+
+    if (res != 0) {
+        puts("ERROR: Unable to init tlsman context!");
+        return -1;
+    }
+
+    res = tlsman_create_channel(&dtls_session, tlsman_flags,
+                          packet_rcvd, DTLS_MAX_BUF);
+
+    if (tlsman_process_is_error_code_nonfatal(res)) {
+        puts("ERROR: Unable to start (D)TLS handhsake process!");
+        return -1;
+    }
+    else if (res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT) {
+        /* NOTE: Handhsake timeout can be not fatal but is part of our test */
+        puts("ERROR: (D)TLS handshake timeout!");
+    }
+
+    while(tlsman_is_channel_ready(&dtls_session)) {
+        /* TODO: Add  user control */
+        printf("Send (%i bytes): \t--%s--\n", sizeof("Ping"), "Ping");
+        tlsman_send_data_app(&dtls_session, "Ping", sizeof("Ping"));
+        xtimer_usleep(100); /* Simulating other operations */
+        tlsman_retrieve_data_app(&dtls_session, packet_rcvd, DTLS_MAX_BUF);
+        xtimer_sleep(5);
+    }
+
+    return 0;
+}
+
+
+int client_cmd(int argc, char **argv)
+{
+
+    if ((argc != 3)) {
+        printf("usage: %s <IPv6 Address> <(UDP|TCP) Port>\n", argv[0]);
+        return 1;
+    }
+
+    /* TODO Add safe guard with the atoi */
+
+    return _client_side(argv[1], atoi(argv[2]) );
+}

--- a/apps/tlsman/keys/dtls_keys.h
+++ b/apps/tlsman/keys/dtls_keys.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tlsman test application (PSK and ECC keys)
+ *
+ * Small test for TLSMAN. Many definitions defined here are also available at
+ * sock_secure (and are intended to be used in standard applications)
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef DTLS_KEYS_H
+#define DTLS_KEYS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  Defautl keys examples for tinyDTLS (for RIOT, Linux and Contiki)
+ */
+#ifdef MODULE_TLSMAN_TINYDTLS
+#ifdef DTLS_PSK
+#define PSK_DEFAULT_IDENTITY "Client_identity"
+#define PSK_DEFAULT_KEY "secretPSK"
+#define PSK_OPTIONS "i:k:"
+#define PSK_ID_MAXLEN 32
+#define PSK_MAXLEN 32
+
+unsigned char psk_id[PSK_ID_MAXLEN] = PSK_DEFAULT_IDENTITY;
+size_t psk_id_length = sizeof(PSK_DEFAULT_IDENTITY) - 1;
+unsigned char psk_key[PSK_MAXLEN] = PSK_DEFAULT_KEY;
+size_t psk_key_length = sizeof(PSK_DEFAULT_KEY) - 1;
+
+#endif /* DTLS_PSK */
+
+#ifdef DTLS_ECC
+static const unsigned char ecdsa_priv_key[] = {
+    0x41, 0xC1, 0xCB, 0x6B, 0x51, 0x24, 0x7A, 0x14,
+    0x43, 0x21, 0x43, 0x5B, 0x7A, 0x80, 0xE7, 0x14,
+    0x89, 0x6A, 0x33, 0xBB, 0xAD, 0x72, 0x94, 0xCA,
+    0x40, 0x14, 0x55, 0xA1, 0x94, 0xA9, 0x49, 0xFA
+};
+
+static const unsigned char ecdsa_pub_key_x[] = {
+    0x36, 0xDF, 0xE2, 0xC6, 0xF9, 0xF2, 0xED, 0x29,
+    0xDA, 0x0A, 0x9A, 0x8F, 0x62, 0x68, 0x4E, 0x91,
+    0x63, 0x75, 0xBA, 0x10, 0x30, 0x0C, 0x28, 0xC5,
+    0xE4, 0x7C, 0xFB, 0xF2, 0x5F, 0xA5, 0x8F, 0x52
+};
+
+static const unsigned char ecdsa_pub_key_y[] = {
+    0x71, 0xA0, 0xD4, 0xFC, 0xDE, 0x1A, 0xB8, 0x78,
+    0x5A, 0x3C, 0x78, 0x69, 0x35, 0xA7, 0xCF, 0xAB,
+    0xE9, 0x3F, 0x98, 0x72, 0x09, 0xDA, 0xED, 0x0B,
+    0x4F, 0xAB, 0xC3, 0x6F, 0xC7, 0x72, 0xF8, 0x29
+};
+#endif /* DTLS_ECC */
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+/* TODO: Default set of keys for WolfSSL*/
+#endif /* MODULE_TLSMAN_WOLFSSL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DTLS_KEYS_H */

--- a/apps/tlsman/main.c
+++ b/apps/tlsman/main.c
@@ -1,0 +1,60 @@
+ #include <stdio.h>
+
+#include "shell.h"
+ #include "msg.h"
+ #include "net/tlsman.h"
+
+#ifndef DTLS_DEFAULT_PORT
+#define DTLS_DEFAULT_PORT 20220 /* DTLS default port */
+#endif
+
+/* List of acceptable cipher suites (T) */
+/* NOTE: For now, only CoAP Secure candidates (RFC 7252 9.1.3) */
+#define SECURE_CIPHER_PSK_IDS (0xC0A8)
+#define SECURE_CIPHER_RPK_IDS (0xC0AE)
+#define SECURE_CIPHER_LIST { SECURE_CIPHER_PSK_IDS, SECURE_CIPHER_RPK_IDS }
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+extern int client_cmd(int argc, char **argv);
+int server_cmd(int argc, char **argv);
+
+static const shell_command_t shell_commands[] = {
+    { "client", "Start the testing clientt", client_cmd},
+    { "server", "Start the testing server", server_cmd},
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("TLSMAN Module example implementation");
+
+    /* The Cipher(s) the application must use (Hardcoded) */
+    int chipers[] = SECURE_CIPHER_LIST;
+    ssize_t res = tlsman_load_stack(chipers, sizeof(chipers), TLSMAN_FLAG_STACK_DTLS);
+
+    switch (res) {
+        case 0:
+            /* start shell */
+            puts("All up, running the shell now");
+            puts("WARNING: Server and Client are one call only!"); /* TODO */
+            char line_buf[SHELL_DEFAULT_BUFSIZE];
+            shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+        break;
+
+        case TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED:
+            puts("tlsman_load_stack: TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED");
+        case TLSMAN_ERROR_CIPHER_NOT_SUPPORTED:
+            puts("tlsman_load_stack: TLSMAN_ERROR_CIPHER_NOT_SUPPORTED");
+        default:
+            puts("ERROR: Unable to load stack ");
+            return -1;
+    }
+
+    return 0;
+}

--- a/apps/tlsman/server.c
+++ b/apps/tlsman/server.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "net/sock/udp.h"
+#include "net/tlsman.h"
+
+#include "msg.h" /* TODO */
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+#ifndef DTLS_DEFAULT_PORT
+#define DTLS_DEFAULT_PORT 20220 /* DTLS default port */
+#endif
+
+#define READER_QUEUE_SIZE (8U)
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
+
+static tlsman_session_t dtls_session;
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
+{
+
+    (void) sock;
+
+    printf("Got (string) data -- ");
+    for (size_t i = 0; i < data_size; i++) {
+        printf("%c", data[i]);
+    }
+    printf(" -- (Total: %i bytes)\n",data_size );
+
+    /* TODO FROM ... */
+    /* NOTE: Remote is already in dtls_session */
+    tlsman_send_data_app(&dtls_session, "Pong", sizeof("Pong"));
+}
+
+void _server_wrapper(void *arg) {
+    (void) arg;
+
+    ssize_t pckt_size = DTLS_MAX_BUF;
+    uint8_t pckt_rcvd[DTLS_MAX_BUF];
+
+    sock_udp_t udp_sock;
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+
+    uint8_t tlsman_flags =  TLSMAN_FLAG_STACK_UNIVERSAL |
+                            TLSMAN_FLAG_SIDE_SERVER;
+
+    /* TODO Prepare (thread) messages reception */
+
+    local.port = DTLS_DEFAULT_PORT;
+    if (sock_udp_create(&udp_sock, &local, NULL, 0) < 0) {
+        puts("ERROR: Unable create sock.");
+        return;
+    }
+
+    ssize_t res = tlsman_init_context((tlsman_ep_t *) &local,
+                                     (tlsman_ep_t *) &remote,
+                                    &dtls_session, &udp_sock,
+                                    _resp_handler, tlsman_flags);
+
+    if (res != 0) {
+        puts("ERROR: Unable to init tlsman context!");
+        return;
+    }
+
+#if ENABLE_DEBUG
+    ipv6_addr_t addrs[GNRC_NETIF_IPV6_ADDRS_NUMOF];
+    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+    if ((netif != NULL) &&
+        ((res = gnrc_netif_ipv6_addrs_get(netif, addrs, sizeof(addrs))) > 0)) {
+        printf("Listening (D)TLS request in: ");
+        for (unsigned i = 0; i < (res / sizeof(ipv6_addr_t)); i++) {
+            printf("[");
+            ipv6_addr_print(&addrs[i]);
+            printf("]:%u\n", DTLS_DEFAULT_PORT);
+        }
+    }
+#endif
+
+    while(tlsman_listening(&dtls_session, tlsman_flags,
+                            pckt_rcvd, DTLS_MAX_BUF)) {
+
+        (void) pckt_size; /* FIXME */
+        xtimer_usleep(500);
+    }
+
+    return;
+}
+
+int server_cmd(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    /* TODO Upgrade this */
+    _server_wrapper(NULL);
+    return 0;
+}

--- a/configuration.sh
+++ b/configuration.sh
@@ -8,6 +8,7 @@ RIOT_BETA="betas"
 
 USR1_RIOT="https://github.com/rfuentess/riot.git"
 USR1_VER1="alpha/sock/secure"
+USR1_VER2="module/tlsman"
 
 USR2_RIOT="https://github.com/miri64/riot.git"
 USR2_VER1="gnrc_sock/feat/async"
@@ -46,6 +47,7 @@ generate(){
     # Betas repositories
     mkdir -p betas
     git clone "${USR1_RIOT}" -b "${USR1_VER1}" "${RIOT_BETA}"/async
+    git clone "${USR1_RIOT}" -b "${USR1_VER2}" "${RIOT_BETA}"/tlsman
 }
 
     cleanup ""


### PR DESCRIPTION
Initial example for TLSMAN

Please, reminds that this module is not intended to be used directly by the user, but by means of another module. These examples are just to show the simplicity in relation to the client/server sides on the dtls-echo example.